### PR TITLE
misc improvements + evals: eval metrics for models and misc tangent improvements (checkpointing, logging, etc.)

### DIFF
--- a/configs/train/base.yaml
+++ b/configs/train/base.yaml
@@ -2,8 +2,9 @@ cfg_name: "simple4"
 dataset_path: "cfg_dataset/simple4_100000_train.txt"
 batch_size: 4
 loss_weighting: "negexp_relpos"
-n_steps: 10000
+n_steps: 1000
 seed: 42
 save_freq: -1
-val_freq: 1000
+val_freq: 100
+n_val_steps: 10
 log_freq: 100

--- a/configs/train/base.yaml
+++ b/configs/train/base.yaml
@@ -1,7 +1,8 @@
-dataset_path: "cfg_dataset/simple4_100000.txt"
-batch_size: 32
-loss_weighting: "unweighted"
-n_steps: 100000
+cfg_name: "simple4"
+dataset_path: "cfg_dataset/simple4_100000_train.txt"
+batch_size: 4
+loss_weighting: "negexp_relpos"
+n_steps: 100
 seed: 42
 save_freq: 2000
-val_freq: 100
+val_freq: 10

--- a/configs/train/base.yaml
+++ b/configs/train/base.yaml
@@ -2,9 +2,11 @@ cfg_name: "simple4"
 dataset_path: "cfg_dataset/simple4_100000_train.txt"
 batch_size: 4
 loss_weighting: "negexp_relpos"
-n_steps: 1000
+n_steps: 10000
 seed: 42
-save_freq: -1
-val_freq: 100
+save_freq: 1000
+save_intermediate: false
+val_freq: 1000
 n_val_steps: 10
 log_freq: 100
+logging: "wandb"

--- a/configs/train/base.yaml
+++ b/configs/train/base.yaml
@@ -2,7 +2,8 @@ cfg_name: "simple4"
 dataset_path: "cfg_dataset/simple4_100000_train.txt"
 batch_size: 4
 loss_weighting: "negexp_relpos"
-n_steps: 100
+n_steps: 10000
 seed: 42
-save_freq: 2000
-val_freq: 10
+save_freq: -1
+val_freq: 1000
+log_freq: 100

--- a/gpt_lw/loss.py
+++ b/gpt_lw/loss.py
@@ -5,7 +5,6 @@ import optax
 from gpt_lw.model_utils import forward
 
 
-# TODO: needs benchmarking, can we make it faster?
 def compute_relative_positions(tokens, delim_token):
     batch_size, seq_len = tokens.shape
     relative_positions = jnp.full_like(tokens, fill_value=-seq_len)

--- a/gpt_lw/model_utils.py
+++ b/gpt_lw/model_utils.py
@@ -43,7 +43,9 @@ def save_model(variables, opt_state, step, path):
 
 def load_model(path):
     with lz4.frame.open(path, 'rb') as f:
-        return cloudpickle.load(f)
+        ckpt = cloudpickle.load(f)
+    variables, opt_state, init_step = ckpt['variables'], ckpt['opt_state'], ckpt['step']
+    return variables, opt_state, init_step
 
 
 # NOTE: not adding any fancy logit warpers (top_k, top_p, etc) here since

--- a/gpt_lw/model_utils.py
+++ b/gpt_lw/model_utils.py
@@ -36,9 +36,9 @@ def forward(model, variables, key, *x, method=None):
     return model.apply(variables, *x, rngs={'gpt': gpt_key, 'dropout': dropout_key}, mutable=list(set(variables) - {'params'}), method=method)
 
 
-def save_model(variables, opt_state, path):
+def save_model(variables, opt_state, step, path):
     with lz4.frame.open(path, 'wb') as f:
-        cloudpickle.dump({'variables': variables, 'opt_state': opt_state}, f)
+        cloudpickle.dump({'variables': variables, 'opt_state': opt_state, 'step': step}, f)
 
 
 def load_model(path):
@@ -46,6 +46,8 @@ def load_model(path):
         return cloudpickle.load(f)
 
 
+# NOTE: not adding any fancy logit warpers (top_k, top_p, etc) here since
+# vocab size is probably too small for it to be relevant
 def sample_model(model, variables, sample_key, batch_size, n_tokens, delim_token):
     tokens = jnp.ones((batch_size, 1), dtype=int) * delim_token
     for i in range(n_tokens):

--- a/gpt_lw/model_zdc.py
+++ b/gpt_lw/model_zdc.py
@@ -110,14 +110,3 @@ class GPT(nn.Module):
             self.config.drop_rate,
             not training
         )(x, pos, mask, training=training)
-
-    def gen(self, batch_size):
-        generated = jnp.empty((batch_size, self.seq_len), dtype=int)
-        next_token = jnp.empty((batch_size, 0), dtype=int)
-
-        for i in range(self.seq_len):
-            logits, state = self(next_token, training=False)
-            next_token = jax.random.categorical(self.make_rng('gpt'), logits[:, 0])
-            generated = generated.at[:, i].set(next_token)
-
-        return generated

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ optax~=0.2.2
 ply~=3.11
 PyYAML~=6.0.1
 tqdm~=4.66.2
+wandb~=0.17.2

--- a/train.py
+++ b/train.py
@@ -8,9 +8,10 @@ import jax.numpy as jnp
 import optax
 from chex import Array
 
+from cfg_dataset.cfg import CFG
 from gpt_lw.data import Tokenizer, get_dataset, sample_batch
 from gpt_lw.loss import get_weighted_loss
-from gpt_lw.model_utils import get_optimizer, init, gradient_step, save_model
+from gpt_lw.model_utils import get_optimizer, init, gradient_step, save_model, sample_model
 from gpt_lw.model_zdc import GPT, GPTConfig
 
 
@@ -18,6 +19,7 @@ def train(
         run_name: str,
         config: GPTConfig,
         dataset: Array,
+        cfg: CFG,
         tokenizer: Tokenizer,
         optimizer: optax.GradientTransformation,
         batch_size: int,
@@ -29,6 +31,11 @@ def train(
         **kwargs
     ):
 
+    # TODO: expand run dir
+    # - auto run name if one not passed
+    # - save config in dir
+    # - logs (.out/.err, loss/acc curves) subdir
+    # - checkpoints subdir
     os.makedirs(f"checkpoints/{run_name}", exist_ok=True)
 
     # gen random keys
@@ -42,15 +49,19 @@ def train(
     # init model
     model = GPT(config)
     inputs = jnp.empty((batch_size, config.seq_len), dtype=int)
-    variables = init(model, init_key, inputs, print_summary=True)
+    variables = init(model, init_key, inputs)
+
+    n_params = sum(x.size for x in jax.tree.leaves(variables['params']))
+    print(f"Model has {n_params} parameters")
 
     # init optimizer
     opt_state = optimizer.init(variables["params"])
 
     # gradient step and eval functions
     loss_fn = get_weighted_loss(model, loss_weighting)
+    eval_fn = get_weighted_loss(model, "unweighted")  # CCE/compression
     step_fn = jax.jit(partial(gradient_step, loss_fn=loss_fn, optimizer=optimizer))
-    eval_fn = jax.jit(loss_fn)
+    eval_fn = jax.jit(eval_fn)
     sample_fn = jax.jit(partial(sample_batch, dataset, batch_size, config.seq_len))
 
     # train loop
@@ -67,6 +78,21 @@ def train(
 
             val_loss, _ = eval_fn(variables, val_key, xt, xtp1)
             print("val_loss: ", val_loss)
+
+            # CFG accuracy eval:
+            # TODO: get delim token from cfg
+            gen_tokens = sample_model(model, variables, val_key, 2, 10, 0)
+
+            # TODO: benchmark and make this faster somehow...
+            tot_cfg_samples = []
+            for i in range(gen_tokens.shape[0]):
+                sample = tokenizer.decode(gen_tokens[i])
+                cfg_samples = sample.split(',')[1:-1]
+                tot_cfg_samples += cfg_samples
+            cfg_acc = sum([cfg.verify(s) for s in tot_cfg_samples]) / len(tot_cfg_samples)
+            print(cfg_acc)
+
+            quit()
 
         if step % save_freq == 0:
             save_model(variables, opt_state, f"checkpoints/{run_name}/step_{step}.pkl")
@@ -86,6 +112,7 @@ if __name__ == "__main__":
     with open(args.train_config) as f:
         train_config = yaml.safe_load(f)
 
+    cfg = CFG(rules_file=f"configs/cfg/{train_config['cfg_name']}.cfg")
     dataset, tokenizer = get_dataset(train_config["dataset_path"])
 
     with open(args.gpt_config) as f:
@@ -100,4 +127,4 @@ if __name__ == "__main__":
 
     optimizer = get_optimizer(**optimizer_config)
 
-    train(args.run_name, gpt_config, dataset, tokenizer, optimizer, **train_config)
+    train(args.run_name, gpt_config, dataset, cfg, tokenizer, optimizer, **train_config)


### PR DESCRIPTION
Summary:

**1. checkpoint handling**
- last checkpoint: run/name/checkpoint/last.pkl always contains the last checkpoint of a run
- no intermediate checkpoints: if you set save_intermediate to false then you only save last.pkl (usually you don't need intermediate checkpoints)
- auto resume: if you re-run with the same run_name you always try to restart from the last checkpoint which also is aware of the step at which you stopped so it won't redo steps
- specify checkpoint: if you want to start from a specific checkpoint you cna specify "checkpoint_path" in the training config which has top priority

**2.  sampling**
- GPT.gen function was not working so I moved it out to utils and wrote my own which is simple but works fine. For now no need for fancy logit warpers since data is super simple and vocab is tiny

**3. evals**
- in eval portion we do n_val_steps validation steps computing both the training loss and the unweighted loss (compression)
- we also compute the CFG accuracy but this is commented for now until we solve our CFG issues

**4. logging**
- wandb integration, just log in and set logging = "wandb" in training config